### PR TITLE
Tweak handling of RichTextArea changes

### DIFF
--- a/js/fieldmanager-beta-customize-overrides.js
+++ b/js/fieldmanager-beta-customize-overrides.js
@@ -73,15 +73,6 @@
 		var editorElement = document.getElementById( editor.id );
 
 		if ( editorElement && editorElement.classList.contains( 'fm-richtext' ) ) {
-			/*
-			 * Debouncing or throttling updates to fields creates an FM-specific
-			 * deviation to how users experience the Customizer adds maintenance
-			 * requirements for the plugin.
-			 *
-			 * Without debouncing or throttling, changes to settings using the
-			 * `postMessage` transport are faster. The Customizer's refresh
-			 * framework also debounces natively.
-			 */
 			editor.on( 'input change keyup', function () {
 				editor.save();
 				fm.beta.customize.setControlsContainingElement( editorElement );

--- a/js/fieldmanager-beta-customize-overrides.js
+++ b/js/fieldmanager-beta-customize-overrides.js
@@ -73,6 +73,15 @@
 		var editorElement = document.getElementById( editor.id );
 
 		if ( editorElement && editorElement.classList.contains( 'fm-richtext' ) ) {
+			/*
+			 * Debouncing or throttling updates to fields creates an FM-specific
+			 * deviation to how users experience the Customizer adds maintenance
+			 * requirements for the plugin.
+			 *
+			 * Without debouncing or throttling, changes to settings using the
+			 * `postMessage` transport are faster. The Customizer's refresh
+			 * framework also debounces natively.
+			 */
 			editor.on( 'input change keyup', function () {
 				editor.save();
 				fm.beta.customize.setControlsContainingElement( editorElement );

--- a/js/fieldmanager-beta-customize-overrides.js
+++ b/js/fieldmanager-beta-customize-overrides.js
@@ -70,12 +70,12 @@
 
 	// Respond to RichTextArea changes.
 	$( document ).on( 'tinymce-editor-init', function ( event, editor ) {
-		var editor_element = document.getElementById( editor.id );
+		var editorElement = document.getElementById( editor.id );
 
-		if ( editor_element && editor_element.classList.contains( 'fm-richtext' ) ) {
+		if ( editorElement && editorElement.classList.contains( 'fm-richtext' ) ) {
 			editor.on( 'keyup AddUndo SetContent', function () {
 				editor.save();
-				fm.beta.customize.setControlsContainingElement( editor_element );
+				fm.beta.customize.setControlsContainingElement( editorElement );
 			});
 		}
 	});

--- a/js/fieldmanager-beta-customize-overrides.js
+++ b/js/fieldmanager-beta-customize-overrides.js
@@ -73,7 +73,7 @@
 		var editorElement = document.getElementById( editor.id );
 
 		if ( editorElement && editorElement.classList.contains( 'fm-richtext' ) ) {
-			editor.on( 'keyup AddUndo SetContent', function () {
+			editor.on( 'input change keyup', function () {
 				editor.save();
 				fm.beta.customize.setControlsContainingElement( editorElement );
 			});

--- a/js/fieldmanager-beta-customize.js
+++ b/js/fieldmanager-beta-customize.js
@@ -49,6 +49,14 @@
 		/**
 		 * Set a Fieldmanager setting to its control's form values.
 		 *
+		 * Updates to fields are generally not debounced or throttled because
+		 * these create FM-specific deviations to how users experience the
+		 * Customizer and add maintenance requirements for the plugin.
+		 *
+		 * Without debouncing or throttling, changes to settings using the
+		 * `postMessage` transport are faster. The Customizer's refresh
+		 * framework also debounces natively.
+		 *
 		 * @param {Object} control Customizer Control object.
 		 * @return {Object} The updated Control.
 		 */

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,9 @@ For more code examples, browse `php/demos/class-fieldmanager-beta-customize-demo
 
 == Changelog ==
 
+= Unreleased =
+* Changed: Use better TinyMCE events for tracking `Fieldmanager_RichTextArea` changes.
+
 = 0.3.1 =
 * Fixed: Track the changes to instances of repeatable RichTextAreas and Colorpickers added after loading the Customizer.
 


### PR DESCRIPTION
This branch started by trying to throttle the number of Customize setting updates that changes in TinyMCE editors caused, but I decided against it for the same reasons I removed a previous implementation -- first written in [the original FM PR](https://github.com/alleyinteractive/wordpress-fieldmanager/pull/399/commits/45bff86c72a59d2c3d85f788065b1447eb51974c) but now documented here.

5da4d5a removes the mishmash of TinyMCE events that the plugin listens for and replaces those with the neater set [from Customize Posts](https://github.com/xwp/wp-customize-posts/commit/c4dc6c59fbecfb0c609932ea19e5331218071aae).